### PR TITLE
Adding gzip functionality

### DIFF
--- a/KV-Store/main.go
+++ b/KV-Store/main.go
@@ -59,6 +59,9 @@ func main() {
 	// Encodes the hash table and outputs to a file
 	encoder.Encode(kv)
 
+	// Zip key value store, kv, and save it to file tinyDB.gz
+	ZipToFile(kv, "tinyDB.gz")
+
 	/*
 		Let's:
 		> read the output file

--- a/KV-Store/ziptofile.go
+++ b/KV-Store/ziptofile.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/gob"
+	"io/ioutil"
+	"log"
+)
+
+func ZipToFile(kvs map[string]string, filename string) {
+	//1. kvs (the key-value store passed as argument to this function)
+	//is a composite datastructure. Before we can write it to file, we have to
+	//encode it. For this we use gob.
+	var kvs_buffer bytes.Buffer
+	encoder := gob.NewEncoder(&kvs_buffer)
+
+	err := encoder.Encode(kvs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//2. Create byte buffer that will hold compressed bytes
+	//and encode (write) the bytes in the kvs_buffer.
+	var zip_buffer bytes.Buffer
+	gzipwriter := gzip.NewWriter(&zip_buffer)
+
+	gzipwriter.Write(kvs_buffer.Bytes())
+	//Close gzipwriter, causing bytes to be flushed to the buffer.
+	gzipwriter.Close()
+
+	//3. Write buffer containing compressed kvs data structure to file.
+	err = ioutil.WriteFile(filename, zip_buffer.Bytes(), 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This pull request adds the functionality requested [in this issue:](https://github.com/RavenWare/Playground/issues/1#issue-85472736)

Steps to verify that the PR solves the issue:
1. Run the program `go run *.go`
2. This will generate a `tinyDB` file, as well as a compressed version `tinyDB.gz`
3. Remove the file `tinyDB` and uncompress the other: `rm tinyDB && gunzip tinyDB.gz`
4. In `main.go`, **comment out lines 28 to 64**, so that no new `tinyDB` file is created
5. Run `go run *.go`, which will then mean that the program is opening the `tinyDB` file which was uncompressed in step 3.

Todo:
Improve testing.